### PR TITLE
compilation error due to line number 64

### DIFF
--- a/src/mem/cache/tags/fifo.cc
+++ b/src/mem/cache/tags/fifo.cc
@@ -61,7 +61,7 @@ Fifo::Fifo(const Params *p)
 CacheBlk* 
 Fifo::accessBlock(Addr addr, bool is_secure, Cycles &lat, int master_id)
 {
-    return BaseSetAssoc::accessBlock(addr, is_secure, lat, master_id);
+    return BaseSetAssoc::accessBlock(addr, is_secure, lat);
 }
 
 CacheBlk*


### PR DESCRIPTION
BaseSetAssoc::accessBlock requires 3 arguments and not 4, but 4 arguements were given in the previous version. The argument "master_id" is unnecessary to call it.